### PR TITLE
Fixes #3: Prevent users from following themselves in the content view

### DIFF
--- a/frontend/src/app/content/components/viewContent.tsx
+++ b/frontend/src/app/content/components/viewContent.tsx
@@ -317,6 +317,12 @@ export default function ViewContent({ id }: ViewContentProps) {
         return;
       }
 
+      if (userUID === content.creatorUID) {
+        console.warn("You cannot follow yourself.");
+        alert("You can't follow yourself."); 
+        return;
+      }
+
       const action = isFollowing ? "unfollow" : "follow";
       const url = `${apiURL}/user/${userUID}/${action}/${content.creatorUID}`;
 
@@ -325,7 +331,6 @@ export default function ViewContent({ id }: ViewContentProps) {
 
     } catch (error) {
       console.error("Error following/unfollowing creator:", error);
-
     }
   };
 


### PR DESCRIPTION
Fixes error thrown and shows alert instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Prevented self-follow actions by displaying an alert when users attempt to follow their own content, ensuring a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->