### PR TITLE
Added 'private' option for profile page - hides stats and shared content

### DIFF
--- a/backend/user-module/models/userModel.ts
+++ b/backend/user-module/models/userModel.ts
@@ -17,4 +17,5 @@ export interface User {
   following?: string[]; // Optional followed creators
   followers?: string[]; // Optional followed by users
   sharedContent?: string[]; // Optional shared content
+  isPrivate?: boolean; // Optional private account
 }

--- a/backend/user-module/services/userService.ts
+++ b/backend/user-module/services/userService.ts
@@ -97,7 +97,7 @@ export async function getUser(uid: string) {
 
 export async function updateUser(
   uid: string,
-  data: Partial<{ email: string; username: string }>
+  data: Partial<{ email: string; username: string; isPrivate: boolean }>
 ) {
   await updateDoc(doc(db, "users", uid), data);
 }
@@ -116,6 +116,7 @@ export async function createUser(
     username: username,
     email: email,
     createdAt: new Date(),
+    isPrivate: false,
   };
 
   await setDoc(doc(db, "users", uid), user);

--- a/frontend/src/app/profile/[id]/manage/page.tsx
+++ b/frontend/src/app/profile/[id]/manage/page.tsx
@@ -580,6 +580,19 @@ export default function Page() {
               />
             </div>
 
+            {/* Privacy Setting */}
+            <div className="input-group">
+              <label htmlFor="isPrivate">Make Profile Private</label>
+              <input
+                type="checkbox"
+                id="isPrivate"
+                checked={user?.isPrivate || false}
+                onChange={(e) =>
+                  setUser(user ? { ...user, isPrivate: e.target.checked } : null)
+                }
+              />
+            </div>
+
             {errorEditProfile && (
               <p className='error-message'>{errorEditProfile}</p>
             )}

--- a/frontend/src/app/styles/profile/ProfileManagement.scss
+++ b/frontend/src/app/styles/profile/ProfileManagement.scss
@@ -33,6 +33,12 @@
   margin: 10px 0;
 }
 
+input[type="checkbox"] {
+  width: auto;
+  margin: 0 0.5rem 0 1rem;
+  cursor: pointer;
+}
+
 input,
 textarea {
   width: 100%;

--- a/frontend/src/components/profile/viewProfile.tsx
+++ b/frontend/src/components/profile/viewProfile.tsx
@@ -309,6 +309,7 @@ export default function ViewProfile({ id }: ViewProfileProps) {
   const followingCount = user?.following ? user.following.length : 0;
   const createdCount = user?.content ? user.content.length : 0;
   const sharedCount = user?.sharedContent ? user.sharedContent.length : 0;
+  const canViewFullProfile = !user?.isPrivate || userUID === id;
 
   return (
     <>
@@ -359,26 +360,32 @@ export default function ViewProfile({ id }: ViewProfileProps) {
                 />
               </button>
             </div>
-
-            {/* Stats */}
-            <div className="profile-stats">
-              <div className="stat-item">
-                <span className="stat-number">{followersCount}</span>
-                <span className="stat-label">Followers</span>
-              </div>
-              <div className="stat-item">
-                <span className="stat-number">{followingCount}</span>
-                <span className="stat-label">Following</span>
-              </div>
-              <div className="stat-item">
-                <span className="stat-number">{createdCount}</span>
-                <span className="stat-label">Created</span>
-              </div>
-              <div className="stat-item">
-                <span className="stat-number">{sharedCount}</span>
-                <span className="stat-label">Shared</span>
-              </div>
-            </div>   
+            
+            {canViewFullProfile ? (
+              <>
+                {/* Stats */}
+                <div className="profile-stats">
+                  <div className="stat-item">
+                    <span className="stat-number">{followersCount}</span>
+                    <span className="stat-label">Followers</span>
+                  </div>
+                  <div className="stat-item">
+                    <span className="stat-number">{followingCount}</span>
+                    <span className="stat-label">Following</span>
+                  </div>
+                  <div className="stat-item">
+                    <span className="stat-number">{createdCount}</span>
+                    <span className="stat-label">Created</span>
+                  </div>
+                  <div className="stat-item">
+                    <span className="stat-number">{sharedCount}</span>
+                    <span className="stat-label">Shared</span>
+                  </div>
+                </div> 
+              </>  
+            ) : (
+              <p>This account is private.</p>
+            )}
 
             <p>
               {user?.firstName} {user?.lastName}
@@ -424,12 +431,16 @@ export default function ViewProfile({ id }: ViewProfileProps) {
       {tab === "shared" && (
         <>
           <h3 className="section-title">Shared Content</h3>
-          {sharedContent.length === 0 ? (
-            <h4>No shared content found</h4>
+                {canViewFullProfile ? (
+            sharedContent.length === 0 ? (
+              <h4>No shared content found</h4>
+            ) : (
+              <div className="content-list">
+                {sharedContent.map((content, index) => renderContentItem(content, index))}
+              </div>
+            )
           ) : (
-            <div className="content-list">
-              {sharedContent.map((content, index) => renderContentItem(content, index))}
-            </div>
+            <p>This account is private.</p>
           )}
         </>
       )}


### PR DESCRIPTION
Users can change their Profile to 'private' using a toggle in the profile management page. Stats and shared content are not visible for private profiles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced user privacy controls allowing profiles to be marked as private. A new checkbox on the profile management page enables users to easily toggle their account visibility.
  - Profiles now conditionally display full details; if privacy is enabled, a message indicates that the account is private.

- **Style**
  - Updated checkbox styling improves the visual appearance and usability of privacy toggles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->