### PR TITLE
feat: implement content preview popup for content tiles

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -7,6 +7,7 @@ import { apiURL } from "./scripts/api";
 import axios from "axios";
 import { User } from "@/models/User";
 import ContentTile from "@/components/content/ContentTile";
+import ContentPreviewPopup from "@/components/content/ContentPreviewPopup";
 
 import "@/app/styles/feed.scss";
 
@@ -14,6 +15,7 @@ export default function Page() {
   const [trendingContent, setTrendingContent] = useState<Content[]>([]);
   const [latestContent, setLatestContent] = useState<Content[]>([]);
   const [personalizedContent, setPersonalizedContent] = useState<Content[]>([]);
+  const [previewContent, setPreviewContent] = useState<Content | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
   const { userUID } = useAuth();
@@ -175,6 +177,14 @@ export default function Page() {
     return content;
   }
 
+  const openPreview = (content: Content) => {
+    setPreviewContent(content);
+  };
+
+  const closePreview = () => {
+    setPreviewContent(null);
+  };
+
   return (
     <div className='main-content'>
       {isLoading && <p>Loading...</p>}
@@ -201,6 +211,7 @@ export default function Page() {
                   key={content.uid || index}
                   content={content}
                   index={index}
+                  onPreview={(c) => openPreview(c)}
                 />
               )}
             </div>
@@ -252,6 +263,12 @@ export default function Page() {
           )}
           {errorPersonalized && <p className='error'>{errorPersonalized}</p>}
         </div>
+      )}
+      {previewContent && (
+        <ContentPreviewPopup
+          content={previewContent}
+          onClose={closePreview}
+        />
       )}
     </div>
   );

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -230,6 +230,7 @@ export default function Page() {
               key={content.uid || index}
               content={content}
               index={index}
+              onPreview={(c) => openPreview(c)}
             />
           ))}
         </div>
@@ -255,6 +256,7 @@ export default function Page() {
                       key={content.uid || index}
                       content={content}
                       index={index}
+                      onPreview={(c) => openPreview(c)}
                     />
                   )}
                 </div>

--- a/frontend/src/app/profile/[id]/page.tsx
+++ b/frontend/src/app/profile/[id]/page.tsx
@@ -23,6 +23,7 @@ import { apiURL } from "@/app/scripts/api";
 // Stylesheets
 import "@/app/styles/profile/profile.scss";
 import ContentTile from "@/components/content/ContentTile";
+import ContentPreviewPopup from "@/components/content/ContentPreviewPopup";
 
 /**
  * Page() -> JSX.Element
@@ -42,6 +43,7 @@ export default function Page() {
   const [isFollowing, setIsFollowing] = useState(false);
   const [followRequested, setFollowRequested] = useState(false);
   const [sharedContent, setSharedContent] = useState<Content[]>([]);
+  const [previewContent, setPreviewContent] = useState<Content | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [tab, setTab] = useState<"created" | "shared">("created");
   const [followUsernames, setFollowUsernames] = useState<{
@@ -382,6 +384,14 @@ export default function Page() {
       return "Unknown User"; // Fallback in case of error
     }
   }
+  
+  const openPreview = (content: Content) => {
+    setPreviewContent(content);
+  };
+
+  const closePreview = () => {
+    setPreviewContent(null);
+  };
 
   if (isLoading) {
     return <div>Loading profile...</div>;
@@ -535,6 +545,7 @@ export default function Page() {
                     key={content.uid || index}
                     content={content}
                     index={index}
+                    onPreview={(c) => openPreview(c)} // Pass the content to the preview function
                   />
                 ))}
               </div>
@@ -569,6 +580,12 @@ export default function Page() {
               <p>This account is private.</p>
             )}
           </>
+        )}
+        {previewContent && (
+          <ContentPreviewPopup
+            content={previewContent}
+            onClose={closePreview}
+          />
         )}
       </div>
     </>

--- a/frontend/src/app/profile/[id]/page.tsx
+++ b/frontend/src/app/profile/[id]/page.tsx
@@ -566,6 +566,7 @@ export default function Page() {
                       key={content.uid || index}
                       content={content}
                       index={index}
+                      onPreview={(c) => openPreview(c)}
                       deleteShareOption={
                         sharedContent.some(
                           (sharedItem) => sharedItem.uid === content.uid

--- a/frontend/src/app/profile/[id]/page.tsx
+++ b/frontend/src/app/profile/[id]/page.tsx
@@ -144,6 +144,14 @@ export default function Page() {
             }
           }
 
+          // Inject user (author) info
+          try {
+            const userRes = await axios.get(`${apiURL}/user/${fetchedContent.creatorUID}`);
+            fetchedContent.user = userRes.data;
+          } catch (userError) {
+            console.error("Failed to fetch author for shared content:", contentId);
+          }
+
           validContent.push(fetchedContent);
         }
       } catch (error) {
@@ -181,6 +189,14 @@ export default function Page() {
         );
       } else if (fetchedContent.dateCreated) {
         fetchedContent.dateCreated = new Date(fetchedContent.dateCreated);
+      }
+
+      // Inject user (author) info
+      try {
+        const userRes = await axios.get(`${apiURL}/user/${fetchedContent.creatorUID}`);
+        fetchedContent.user = userRes.data;
+      } catch (userError) {
+        console.error("Failed to fetch author for content:", contentId);
       }
 
       fetchedContent.uid = contentId; // Ensure the ID is set

--- a/frontend/src/app/styles/content/contentPreviewPopup.scss
+++ b/frontend/src/app/styles/content/contentPreviewPopup.scss
@@ -57,7 +57,7 @@
   font-size: 1.5rem;
   font-weight: bold;
   margin: 10px 0;
-  margin-bottom: 0.25Drem;
+  margin-bottom: 0.25rem;
 }
 
 .popup-summary {

--- a/frontend/src/app/styles/content/contentPreviewPopup.scss
+++ b/frontend/src/app/styles/content/contentPreviewPopup.scss
@@ -57,19 +57,70 @@
   font-size: 1.5rem;
   font-weight: bold;
   margin: 10px 0;
+  margin-bottom: 0.25Drem;
 }
 
 .popup-summary {
-  font-size: 1rem;
-  margin: 15px 0;
+  margin-top: 1rem;
+  padding: 0.75rem 1rem;
+  background-color: rgba(255, 255, 255, 0.05); 
+  border-left: 4px solid #7dd3fc; 
+  border-radius: 0.5rem;
+  font-size: 0.95rem;
+  color: #eee;
+  line-height: 1.6;
+  white-space: pre-line;
 }
+
+.popup-summary::before {
+  content: "Summary";
+  display: block;
+  font-weight: bold;
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
+  color: #93c5fd; 
+}
+
 
 .popup-stats {
   display: flex;
-  justify-content: space-around;
-  margin-bottom: 20px;
+  justify-content: center;
+  gap: 1.5rem;
+  margin-bottom: 2rem;
   font-size: 0.9rem;
   opacity: 0.9;
+}
+
+.popup-author {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  justify-content: center;
+  margin-bottom: 1.5rem;
+  cursor: pointer;
+
+  .author-image {
+    border-radius: 50%;
+  }
+
+  .author-details {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+
+    .author-username {
+      font-weight: 600;
+      color: #fff;
+      margin-bottom: 0.25rem;
+    }
+
+    .author-stats {
+      display: flex;
+      gap: 1rem;
+      font-size: 0.85rem;
+      color: #ccc;
+    }
+  }
 }
 
 .view-page-button {

--- a/frontend/src/app/styles/content/contentPreviewPopup.scss
+++ b/frontend/src/app/styles/content/contentPreviewPopup.scss
@@ -1,0 +1,92 @@
+@use "../colors.scss";
+@use "../global.scss";
+
+.glassmorphic-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(10px);
+  z-index: 1000;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.glassmorphic-popup {
+  @include global.glassmorphic-background;
+  padding: 30px 40px;
+  border-radius: 25px;
+  max-width: 500px;
+  width: 90%;
+  position: relative;
+  text-align: center;
+  color: var(--text-color);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.3);
+  font-family: var(--font-body);
+}
+
+.close-button {
+  position: absolute;
+  top: 10px;
+  right: 15px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-color);
+}
+
+.icon {
+  width: 24px;
+  height: 24px;
+}
+
+.popup-thumbnail {
+  border-radius: 10px;
+  margin-bottom: 15px;
+  max-width: 100%;
+  height: auto;
+  object-fit: cover;
+}
+
+.popup-title {
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin: 10px 0;
+}
+
+.popup-summary {
+  font-size: 1rem;
+  margin: 15px 0;
+}
+
+.popup-stats {
+  display: flex;
+  justify-content: space-around;
+  margin-bottom: 20px;
+  font-size: 0.9rem;
+  opacity: 0.9;
+}
+
+.view-page-button {
+  padding: 10px 20px;
+  border-radius: 10px;
+  border: 1px solid var(--input-border-color);
+  background-color: var(--background-color);
+  color: var(--text-color);
+  cursor: pointer;
+
+  &:hover {
+    background-color: var(--input-border-color);
+  }
+
+  &:active {
+    transform: scale(0.95);
+  }
+}
+
+  

--- a/frontend/src/app/styles/content/contentPreviewPopup.scss
+++ b/frontend/src/app/styles/content/contentPreviewPopup.scss
@@ -88,5 +88,3 @@
     transform: scale(0.95);
   }
 }
-
-  

--- a/frontend/src/app/styles/content/contentTile.scss
+++ b/frontend/src/app/styles/content/contentTile.scss
@@ -120,3 +120,20 @@
 .content-tile-info {
   margin-bottom: 20px;
 }
+
+.preview-inline-button {
+  background-color: var(--tile-color);
+  border: 1px solid var(--input-border-color);
+  padding: 3px 8px;
+  border-radius: 10px;
+  color: var(--text-color); 
+  font-size: 0.85rem;
+  margin-left: 10px;
+  cursor: pointer;
+
+  &:hover {
+    background-color: var(--input-border-color);
+    color: var(--background-color); 
+  }
+}
+

--- a/frontend/src/components/content/ContentPreviewPopup.tsx
+++ b/frontend/src/components/content/ContentPreviewPopup.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { Content } from "@/models/Content";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+import { XMarkIcon } from "@heroicons/react/24/outline";
+
+import "@/app/styles/content/contentPreviewPopup.scss";
+
+interface ContentPreviewPopupProps {
+  content: Content;
+  onClose: () => void;
+}
+
+export default function ContentPreviewPopup({ content, onClose }: ContentPreviewPopupProps) {
+  const router = useRouter();
+
+  const viewContentPage = () => {
+    router.push(`/content/${content.uid}`);
+  };
+
+  return (
+    <div className="glassmorphic-overlay" onClick={onClose}>
+      <div className="glassmorphic-popup" onClick={(e) => e.stopPropagation()}>
+        <button className="close-button" onClick={onClose}>
+          <XMarkIcon className="icon" />
+        </button>
+        {content.thumbnail && (
+          <Image
+            src={content.thumbnail}
+            alt="Content Thumbnail"
+            width={300}
+            height={200}
+            className="popup-thumbnail"
+          />
+        )}
+        <h3 className="popup-title">{content.title}</h3>
+        {content.summary && <p className="popup-summary">{content.summary}</p>}
+        <div className="popup-stats">
+          <span>Likes: {content.likes || 0}</span>
+          <span>Views: {content.views || 0}</span>
+          <span>Shares: {content.shares || 0}</span>
+        </div>
+        <button className="view-page-button" onClick={viewContentPage}>
+          View Page
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/content/ContentPreviewPopup.tsx
+++ b/frontend/src/components/content/ContentPreviewPopup.tsx
@@ -1,14 +1,18 @@
 "use client";
 
 import { Content } from "@/models/Content";
+import { User } from "@/models/User";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 
 import "@/app/styles/content/contentPreviewPopup.scss";
 
+interface ContentWithUser extends Content {
+  user?: User;
+}
 interface ContentPreviewPopupProps {
-  content: Content;
+  content: ContentWithUser;
   onClose: () => void;
 }
 
@@ -25,6 +29,7 @@ export default function ContentPreviewPopup({ content, onClose }: ContentPreview
         <button className="close-button" onClick={onClose}>
           <XMarkIcon className="icon" />
         </button>
+  
         {content.thumbnail && (
           <Image
             src={content.thumbnail}
@@ -34,13 +39,51 @@ export default function ContentPreviewPopup({ content, onClose }: ContentPreview
             className="popup-thumbnail"
           />
         )}
+  
         <h3 className="popup-title">{content.title}</h3>
-        {content.summary && <p className="popup-summary">{content.summary}</p>}
+
         <div className="popup-stats">
           <span>Likes: {content.likes || 0}</span>
           <span>Views: {content.views || 0}</span>
           <span>Shares: {content.shares || 0}</span>
         </div>
+  
+        {/* Author section */}
+        {content.user &&
+          (() => {
+            const user = content.user;
+            return (
+              <div
+                className="popup-author"
+                onClick={() => router.push(`/profile/${user.uid}`)}
+              >
+                {user.profileImage && (
+                  <Image
+                    src={user.profileImage}
+                    alt="Author"
+                    width={40}
+                    height={40}
+                    className="author-image"
+                  />
+                )}
+                <div className="author-details">
+                  <span className="author-username">@{content.user.username}</span>
+                  <div className="author-stats">
+                    <span>Followers: {content.user.followers?.length || 0}</span>
+                    <span>Following: {content.user.following?.length || 0}</span>
+                  </div>
+                </div>
+              </div>
+            );
+          })()}
+          
+        {/* Summary */}
+        {content.summary && (
+          <p className="popup-summary">{content.summary}</p>
+        )}
+  
+        
+  
         <button className="view-page-button" onClick={viewContentPage}>
           View Page
         </button>

--- a/frontend/src/components/content/ContentTile.tsx
+++ b/frontend/src/components/content/ContentTile.tsx
@@ -25,6 +25,7 @@ interface ContentTileProps {
   hideStats?: boolean;
   deleteShareOption?: boolean;
   handleUnshare?: (contentId: string) => void;
+  onPreview?: (content: Content) => void;
 }
 
 export default function ContentTile({
@@ -33,6 +34,7 @@ export default function ContentTile({
   hideStats = false,
   deleteShareOption = false,
   handleUnshare = () => {},
+  onPreview,
 }: ContentTileProps) {
   const router = useRouter();
   const { userUID } = useAuth();
@@ -69,6 +71,17 @@ export default function ContentTile({
                 content.readtime ? ` - ${content.readtime} min read` : ""
               }`
             : ""}
+            {onPreview && (
+              <button
+              className="preview-inline-button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onPreview(content);
+              }}
+            >
+              Preview
+            </button>
+            )}
         </p>
       </div>
 

--- a/frontend/src/models/Content.ts
+++ b/frontend/src/models/Content.ts
@@ -1,3 +1,5 @@
+import { User } from "./User";
+
 export interface Content {
   uid: string; // Firebase UID
   creatorUID: string; // Content Creator UID
@@ -18,4 +20,5 @@ export interface Content {
   titleLower?: string; // Lowercase title, used for sharing.
   sharedBy?: string[]; // List of user IDs who shared the post
   score?: number; // Score of the content
+  user?: User; // User who created the content - supports author injection
 }


### PR DESCRIPTION
- Added inline "Preview" button to all ContentTile instances
- Created reusable ContentPreviewPopup component with thumbnail, stats, and View Page button
- Applied global glassmorphic styling for modal consistency
- Ensured font and layout matched existing search modal
- Integrated preview functionality into home feed and profile views

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced interactive content preview functionality on main and profile pages, allowing users to click on content items to view detailed information in an overlay popup.
  - Added an inline preview button on content tiles to easily trigger the preview mode.

- **Style**
  - Enhanced the visual design with a modern glassmorphic overlay and responsive popup styling, improving overall user engagement.
  - Added new styles for the preview button and popup components, enhancing visual consistency and user interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->